### PR TITLE
Added missing lxml dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 colorama
-lxml
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 colorama
+lxml
 requests

--- a/serenity
+++ b/serenity
@@ -14,13 +14,11 @@
   abaykandotcom
 """
 
-from insides import *
-from sys     import argv
-import requests, json
+import json
 import optparse
-import os, re
-from lxml import html
-import sys
+from sys import argv
+
+from insides import *
 
 ################################  Banner   ################################
 


### PR DESCRIPTION
# Description

After cloning the project and creating a virtual environment with python 2.7.14 and installing colorama and requests, I tried running the script and it failed because I was missing lxml.

`Traceback (most recent call last):
  File "serenity", line 22, in <module>
    from lxml import html
ImportError: No module named lxml`

Installing lxml got it going so I decided to add it to the requirements.txt.

# How Has This Been Tested?

I ran the script successfully: `python serenity --all hack.me`
