### PR TITLE
Added python 3 support.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 colorama
+lxml
 requests


### PR DESCRIPTION
# Description

I made a lot of changes in order to get it to work under python 3.7.3. I refactored a lot of the code because there was a lot of repeated code. On another positive note, unless my connection was flaking out on me, I fixed a bug that you had in `hostsearch()`. On my initial run before making any changes I got this:

`Searching Host 'http://hack.me'
----------------------------------

[#] error check your search parameter`

That section is now returning results.

# How Has This Been Tested?

I ran: `python serenity --all hack.me` under both python 3.7.3 and 2.7.14
